### PR TITLE
[jdbc] Reduce the default character limit for `VARCHAR` columns in MySQL

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMariadbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMariadbDAO.java
@@ -56,8 +56,10 @@ public class JdbcMariadbDAO extends JdbcBaseDAO {
      */
     private void initSqlTypes() {
         logger.debug("JDBC::initSqlTypes: Initialize the type array");
+
+        // MariaDB using utf-8 max = 16383, using 16383-128 = 16255
         sqlTypes.put("IMAGEITEM", "VARCHAR(16255)");
-        sqlTypes.put("STRINGITEM", "VARCHAR(16255)"); // MariaDB using utf-8 max = 16383, using 16383-128 = 16255
+        sqlTypes.put("STRINGITEM", "VARCHAR(16255)");
     }
 
     /**

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMysqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMysqlDAO.java
@@ -60,7 +60,10 @@ public class JdbcMysqlDAO extends JdbcBaseDAO {
      */
     private void initSqlTypes() {
         logger.debug("JDBC::initSqlTypes: Initialize the type array");
-        sqlTypes.put("STRINGITEM", "VARCHAR(21717)");// mysql using utf-8 max 65535/3 = 21845, using 21845-128 = 21717
+
+        // MySQL using utf8mb4 max 65535/4 = 16383, using 16383-128 = 16255
+        sqlTypes.put("IMAGEITEM", "VARCHAR(16255)");
+        sqlTypes.put("STRINGITEM", "VARCHAR(16255)");
     }
 
     /**


### PR DESCRIPTION
pr_rerun 13920-jdbc-mysql-varchar-utf8mb4 to main