### PR TITLE
Bump org.bouncycastle:bcprov-jdk18on from 1.75 to 1.78 in /bundles/org.openhab.binding.androidtv

### DIFF
--- a/bundles/org.openhab.binding.androidtv/pom.xml
+++ b/bundles/org.openhab.binding.androidtv/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.75</version>
+      <version>1.78</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
pr_rerun dependabot/maven/bundles/org.openhab.binding.androidtv/org.bouncycastle-bcprov-jdk18on-1.78 to main