### PR TITLE
[luxtronikheatpump] Fix control signal circulating pump

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/README.md
+++ b/bundles/org.openhab.binding.luxtronikheatpump/README.md
@@ -207,7 +207,7 @@ The following channels are holding read only values:
 | highPressure | Number:Pressure | x | High pressure |
 | lowPressure | Number:Pressure | x | Low pressure |
 | outputCompressorHeating | Switch | x | Output compressor heating |
-| controlSignalCirculatingPump | Number:Energy | x | Control signal circulating pump |
+| controlSignalCirculatingPump | Number:Dimensionless | x | Heating circulating pump power in % |
 | fanSpeed | Number | x | Fan speed |
 | temperatureSafetyLimitFloorHeating | Switch | x | Safety temperature limiter floor heating |
 | powerTargetValue | Number:Energy | x | Power target value |

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
@@ -1572,9 +1572,8 @@
 	</channel-type>
 
 	<channel-type id="controlSignalCirculatingPump" advanced="true">
-		<item-type>Number:Energy</item-type>
-		<label>Control Signal Circulating Pump</label>
-		<category>Energy</category>
+		<item-type>Number:Dimensionless</item-type>
+		<label>Heating Circulating Pump Power</label>
 		<state pattern="%.1f %%" readOnly="true"/>
 	</channel-type>
 


### PR DESCRIPTION
pr_rerun QDinsight:15836-Failed-to-update-item-ControlSignalCirculatingPump-after-upgrading-to-OH4 to main