### PR TITLE
[Freeboxos] Fix `NullPointerException` when updating inactive Player

### DIFF
--- a/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
+++ b/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
@@ -87,6 +87,8 @@ public class ActivePlayerHandler extends PlayerHandler implements FreeDeviceIntf
                 } else {
                     uptime = 0;
                 }
+            } else {
+                updateStatus(ThingStatus.OFFLINE);
             }
             updateChannelQuantity(SYS_INFO, UPTIME, uptime, Units.SECOND);
         }

--- a/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
+++ b/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
@@ -31,6 +31,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.binding.ThingHandlerService;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
+++ b/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
@@ -59,8 +59,10 @@ public class ActivePlayerHandler extends PlayerHandler implements FreeDeviceIntf
         Player player = getManager(PlayerManager.class).getDevice(getClientId());
         if (player.reachable()) {
             Configuration config = getManager(PlayerManager.class).getConfig(player.id());
-            properties.put(Thing.PROPERTY_SERIAL_NUMBER, config.serial());
-            properties.put(Thing.PROPERTY_FIRMWARE_VERSION, config.firmwareVersion());
+            if (config != null) {
+                properties.put(Thing.PROPERTY_SERIAL_NUMBER, config.serial());
+                properties.put(Thing.PROPERTY_FIRMWARE_VERSION, config.firmwareVersion());
+            }
         }
     }
 
@@ -68,15 +70,24 @@ public class ActivePlayerHandler extends PlayerHandler implements FreeDeviceIntf
     protected void internalPoll() throws FreeboxException {
         super.internalPoll();
         if (thing.getStatus().equals(ThingStatus.ONLINE)) {
-            Status status = getManager(PlayerManager.class).getPlayerStatus(getClientId());
-            updateChannelString(PLAYER_STATUS, PLAYER_STATUS, status.powerState().name());
-            ForegroundApp foreground = status.foregroundApp();
-            if (foreground != null) {
-                updateChannelString(PLAYER_STATUS, PACKAGE, foreground._package());
+            Player player = getManager(PlayerManager.class).getDevice(getClientId());
+            updateStatus(player.reachable() ? ThingStatus.ONLINE : ThingStatus.OFFLINE);
+            if (player.reachable()) {
+                Status status = getManager(PlayerManager.class).getPlayerStatus(getClientId());
+                if (status != null) {
+                    updateChannelString(PLAYER_STATUS, PLAYER_STATUS, status.powerState().name());
+                    ForegroundApp foreground = status.foregroundApp();
+                    if (foreground != null) {
+                        updateChannelString(PLAYER_STATUS, PACKAGE, foreground._package());
+                    }
+                }
+                Configuration config = getManager(PlayerManager.class).getConfig(getClientId());
+                if (config != null) {
+                    uptime = checkUptimeAndFirmware(config.uptimeVal(), uptime, config.firmwareVersion());
+                } else {
+                    uptime = 0;
+                }
             }
-            Configuration config = getManager(PlayerManager.class).getConfig(getClientId());
-
-            uptime = checkUptimeAndFirmware(config.uptimeVal(), uptime, config.firmwareVersion());
             updateChannelQuantity(SYS_INFO, UPTIME, uptime, Units.SECOND);
         }
     }
@@ -84,7 +95,9 @@ public class ActivePlayerHandler extends PlayerHandler implements FreeDeviceIntf
     public void reboot() {
         processReboot(() -> {
             try {
-                getManager(PlayerManager.class).reboot(getClientId());
+                if (!getManager(PlayerManager.class).reboot(getClientId())) {
+                    logger.warn("Unable to reboot the player - probably not reachable");
+                }
             } catch (FreeboxException e) {
                 logger.warn("Error rebooting: {}", e.getMessage());
             }

--- a/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
+++ b/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
@@ -35,8 +35,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link ActivePlayerHandler} is responsible for handling everything associated to Freebox Player with api
- * capabilities.
+ * The {@link ActivePlayerHandler} is responsible for handling everything associated to Freebox Player
+ * with api capabilities.
  *
  * @author Gaël L'hopital - Initial contribution
  */

--- a/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
+++ b/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/ActivePlayerHandler.java
@@ -31,7 +31,6 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.binding.ThingHandlerService;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -87,8 +86,6 @@ public class ActivePlayerHandler extends PlayerHandler implements FreeDeviceIntf
                 } else {
                     uptime = 0;
                 }
-            } else {
-                updateStatus(ThingStatus.OFFLINE);
             }
             updateChannelQuantity(SYS_INFO, UPTIME, uptime, Units.SECOND);
         }


### PR DESCRIPTION
pr_rerun QDinsight:freeboxos_npe_activeplayer to main