### PR TITLE
Bump org.bouncycastle:bcprov-jdk18on from 1.75 to 1.78 in /bundles/org.openhab.binding.androidtv

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       - name: Checkout
         if: github.head_ref == ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
 
       - name: Checkout merge
         if: github.head_ref != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         with:
           ref: refs/pull/${{github.event.pull_request.number}}/merge
 
@@ -45,21 +45,21 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         if: ${{ matrix.java != 'profile-j21' }}
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         if: ${{ matrix.java == 'profile-j21' }}
         with:
           distribution: 'temurin'
           java-version: ${{ 21 }}
 
       - name: Set up Maven ${{ matrix.maven }}
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
         with:
           maven-version: ${{ matrix.maven }}
 
@@ -72,7 +72,7 @@ jobs:
       - name: Get Changed Files
         if: github.head_ref != ''
         id: files
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c
         with:
           format: 'csv'
 
@@ -116,7 +116,7 @@ jobs:
 
       - name: Report SAT Errors as Annotations
         if: ${{ matrix.java == '17' && always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
-        uses: ghys/checkstyle-github-action@main
+        uses: ghys/checkstyle-github-action@bd34573c2add8a11e78be993ca937a7bb2e97d05
         with:
           title: CheckStyle Violations
           path: '**/checkstyle-result.xml'

--- a/bundles/org.openhab.binding.androidtv/pom.xml
+++ b/bundles/org.openhab.binding.androidtv/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.75</version>
+      <version>1.78</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
pr_rerun dependabot/maven/bundles/org.openhab.binding.androidtv/org.bouncycastle-bcprov-jdk18on-1.78 to main